### PR TITLE
Update strings.json

### DIFF
--- a/custom_components/sensecraft/strings.json
+++ b/custom_components/sensecraft/strings.json
@@ -55,8 +55,8 @@
         }
       },
       "local_sscma": {
-        "title": "grove_vision_ai_we2",
-        "description": "Config grove_vision_ai_we2",
+        "title": "grove_vision_ai_v2",
+        "description": "Config grove_vision_ai_v2",
         "data": {
           "id": "Id"
         }


### PR DESCRIPTION
Error in name: grove_vision_ai_we2. The  SenseCraft extension try to integrate my Groove Vision AI V2, the name header start with grove_vision_ai_we2_uniqueid and not grove_vision_ai_v2_uniqueid.